### PR TITLE
Fix publish workflow issues

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,13 +1,16 @@
 name: Publish to Maven Central
 
 on:
-  push:
+  workflow_run:
+    workflows: ["Java CI with Maven"]
+    types:
+      - completed
     branches: [ "main" ]
 
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.repository == 'ReforgeHQ/sdk-java'
+    if: github.repository == 'ReforgeHQ/sdk-java' && github.event.workflow_run.conclusion == 'success'
 
     steps:
     - name: "Checkout"
@@ -85,10 +88,10 @@ jobs:
 
     - name: Create GitHub Release
       if: steps.version_check.outputs.should_publish == 'true'
-      uses: ncipollo/create-release@v1
+      uses: softprops/action-gh-release@v2.3.3
       with:
-        tag: "v${{ steps.extract_version.outputs.version }}"
+        tag_name: "v${{ steps.extract_version.outputs.version }}"
         name: "Release v${{ steps.extract_version.outputs.version }}"
-        generateReleaseNotes: true
+        generate_release_notes: true
         draft: false
         prerelease: ${{ contains(steps.extract_version.outputs.version, 'RC') || contains(steps.extract_version.outputs.version, 'beta') || contains(steps.extract_version.outputs.version, 'alpha') }}


### PR DESCRIPTION
## Summary
- Fix invalid GitHub Action that was causing workflow failures
- Add proper workflow dependency to ensure tests pass before publishing

## Changes Made
- **Action Fix**: Replace `ncipollo/create-release` (invalid) with `softprops/action-gh-release@v2.3.3`
- **Workflow Dependency**: Publish workflow now triggers only after "Java CI with Maven" completes successfully
- **Safety**: Ensures artifacts are only published when all tests pass

## Test plan
- [ ] Verify workflow runs without "repository not found" error
- [ ] Confirm publish workflow waits for CI completion
- [ ] Test that failed CI prevents publishing

🤖 Generated with [Claude Code](https://claude.ai/code)