### PR TITLE
Fix plugin version conflicts and build issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -290,7 +290,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>3.6.0</version>
+            <version>3.5.0</version>
             <executions>
               <execution>
                 <id>attach-javadocs</id>
@@ -303,7 +303,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-source-plugin</artifactId>
-            <version>3.3.0</version>
+            <version>3.2.1</version>
             <executions>
               <execution>
                 <id>attach-sources</id>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -160,7 +160,6 @@
           <execution>
             <goals>
               <goal>generate</goal>
-              <goal>generate-test</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
## Summary
- Fix Maven plugin version conflicts preventing Central Repository publishing
- Resolve protobuf duplicate class generation causing build failures

## Changes Made
- **Plugin Version Alignment**: Update maven-javadoc-plugin (3.5.0) and maven-source-plugin (3.2.1) to match basepom parent managed versions
- **Protobuf Configuration**: Remove unnecessary `generate-test` goal that was creating duplicate `Prefab.java` classes

## Issues Resolved
- ❌ **Before**: `Version mismatch for plugin...managed version X does not match project version Y`
- ❌ **Before**: `Found duplicate classes/resources in test classpath` (duplicate-finder failure)
- ✅ **After**: Clean build with `mvn clean verify -P release` passes all checks

## Test Results
- 202 tests pass ✅
- GPG signing works ✅  
- Sources and javadocs generate correctly ✅
- No plugin version conflicts ✅
- No duplicate class detection issues ✅

🤖 Generated with [Claude Code](https://claude.ai/code)