### PR TITLE
Disable conflicting Nexus Staging plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
   <properties>
     <basepom.check.skip-license>true</basepom.check.skip-license>
     <basepom.check.skip-spotbugs>true</basepom.check.skip-spotbugs>
+    <basepom.nexus-staging.skip>true</basepom.nexus-staging.skip>
     <dep.failsafe.version>3.3.2</dep.failsafe.version>
     <dep.guava.version>32.1.3-jre</dep.guava.version>
     <dep.jackson.version>2.15.3</dep.jackson.version>
@@ -247,6 +248,13 @@
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
         <extensions>true</extensions>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.plugins</groupId>
+        <artifactId>nexus-staging-maven-plugin</artifactId>
+        <configuration>
+          <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+        </configuration>
       </plugin>
     </plugins>
 


### PR DESCRIPTION
## Summary
Fix publishing failure by disabling the old nexus-staging-maven-plugin that conflicts with the new central-publishing-maven-plugin.

## Problem
The basepom parent automatically enables nexus-staging-maven-plugin, which tries to run after central-publishing completes, causing:
```
Server credentials with ID "sonatype-nexus-staging" not found!
```

## Solution
- Add `basepom.nexus-staging.skip=true` property
- Configure `skipNexusStagingDeployMojo=true` in plugin configuration
- This allows only the central-publishing-maven-plugin to handle deployment

## Test Results
Central Repository publishing was successful:
✅ 13 files staged successfully  
✅ All checksums generated  
✅ GPG signatures created  

🤖 Generated with [Claude Code](https://claude.ai/code)